### PR TITLE
Node Recovery Use Case

### DIFF
--- a/node_recover.yml
+++ b/node_recover.yml
@@ -1,15 +1,22 @@
 ---
-# Sets up the cluster
+# This playbook should be run against a cluster when a node is rebuilt.
+# It will re-authenticate the node to the cluster and add it back in.
 
-- name: Prerequisites
+- name: Gather Facts
+  hosts: cluster_nodes
+  tasks: []
+
+- name: Distribute SSH Keys
   hosts: cluster_nodes
   tasks:
-  # Distribute SSH Keys
   - include: tasks/distribute_ssh_keys.yml
-  
+
+- hosts: cluster_nodes
+  serial: 1
+  pre_tasks:
   # Register to Satellite
   - include: tasks/register_to_satellite.yml
-  
+
   # Install some packages
   - name: Install pre-requisites
     yum: name={{ item }} state=present
@@ -17,9 +24,6 @@
     - libsemanage-python
     - nfs-utils
   
-- name: Set up cluster
-  hosts: cluster_nodes
-  pre_tasks:
   # Add the NFS mount point for our guests
   - name: Add NFS mount point
     mount:
@@ -39,16 +43,14 @@
   
   post_tasks:
   - name: Authenticate Cluster
-    run_once: true
     command: >
       pcs cluster auth -u hacluster -p {{ cluster_password }}
       {% for host in groups['cluster_nodes'] %}
       {{ hostvars[host]['ansible_hostname'] }}
       {% endfor %}
-      creates=/var/lib/pcsd/tokens
-  
+      creates=/var/lib/pcsd/tokens 
+ 
   - name: Create Cluster
-    run_once: true
     command: >
       pcs cluster setup --name store
       {% for host in groups['cluster_nodes'] %}
@@ -61,7 +63,4 @@
   
   - name: Enable Cluster Services
     command: pcs cluster enable
-  
-  - name: Disable STONITH
-    run_once: true
-    command: pcs property set stonith-enabled=false
+

--- a/roles/virtualization_host/tasks/main.yml
+++ b/roles/virtualization_host/tasks/main.yml
@@ -5,21 +5,6 @@
 - name: Start firewall
   service: name=firewalld state=started enabled=yes
 
-# Distribute SSH keys for live migration
-  # Setup SSH Keys
-- name: Generate SSH key
-  user: name=root generate_ssh_key=yes
-  register: rootkeys
-  
-# Distribute SSH Keys
-- name: Distribute SSH keys
-  authorized_key:
-    key: "{{ hostvars[item].rootkeys.ssh_public_key }}"
-    state: present
-    user: root
-  with_items:
-    "{{ groups['cluster_nodes'] }}"
-  
 - name: Firewall rule for pcsd
   firewalld: service=ssh permanent=true state=enabled immediate=yes
 

--- a/tasks/distribute_ssh_keys.yml
+++ b/tasks/distribute_ssh_keys.yml
@@ -1,0 +1,14 @@
+---
+# Setup SSH Keys
+- name: Generate SSH key
+  user: name=root generate_ssh_key=yes
+  register: rootkeys
+  
+# Distribute SSH Keys
+- name: Distribute SSH keys
+  authorized_key:
+    key: "{{ hostvars[item].rootkeys.ssh_public_key }}"
+    state: present
+    user: root
+  with_items:
+    "{{ groups['cluster_nodes'] }}"

--- a/tasks/register_to_satellite.yml
+++ b/tasks/register_to_satellite.yml
@@ -1,0 +1,10 @@
+---
+# Register to Satellite
+- name: Download Satellite 6 config RPM
+  yum: name=http://{{ satellite_url }}/pub/katello-ca-consumer-latest.noarch.rpm state=present
+
+- name: Register to Satellite
+  redhat_subscription:
+    state: present
+    activationkey: "{{ satellite_key }}"
+    org_id: "{{ satellite_org }}"


### PR DESCRIPTION
Adds new "node_recover" playbook which can be used on an existing cluster when a node is rebuilt.
Refactors setup playbook a bit - breaks out some common tasks between the two use cases.
Also fixes an issue where a cluster property was trying to be set prior to the cluster being on-line.